### PR TITLE
Add _moveWindowButtons support for -moz-gtk-csd-reversed-placement

### DIFF
--- a/src/browser/base/content/ZenCustomizableUI.sys.mjs
+++ b/src/browser/base/content/ZenCustomizableUI.sys.mjs
@@ -71,7 +71,7 @@ export var ZenCustomizableUI = new (class {
   _moveWindowButtons(window) {
     const windowControls = window.document.getElementsByClassName('titlebar-buttonbox-container');
     const toolboxIcons = window.document.getElementById('zen-sidebar-top-buttons-customization-target');
-    if (window.AppConstants.platform === 'macosx') {
+    if (window.AppConstants.platform === 'macosx'|| matchMedia('(-moz-gtk-csd-reversed-placement)').matches) {
       for (let i = 0; i < windowControls.length; i++) {
         if (i === 0) {
           toolboxIcons.prepend(windowControls[i]);


### PR DESCRIPTION
I add 'or' operator to set window buttons if  -moz-gtk-csd-reversed-placement is true